### PR TITLE
base: enable docker system prune timer

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -151,6 +151,11 @@ with lib;
         config.fileSystems."/".fsType == "zfs";
     };
 
+    virtualisation.docker.autoPrune = {
+      enable = mkDefault true;
+      flags = [ "--all" ];
+    };
+
     virtualisation.libvirtd.qemuVerbatimConfig = ''
       namespaces = []
       set_process_name = 1


### PR DESCRIPTION
Enables the systemd-timer for the `docker-prune` service. It runs `weekly` by default.