### PR TITLE
monitoring: add missing path for node-filesystem-collector

### DIFF
--- a/monitoring/default.nix
+++ b/monitoring/default.nix
@@ -218,7 +218,7 @@ in {
           "conntrack"
           "diskstats"
           "filefd"
-          "filesystem"
+          "filesystem /run/prometheus-node-exporter"
           "netdev"
           "netstat"
           "time"


### PR DESCRIPTION
The filesystem collector requires a target directory to be passed.