### PR TITLE
monitoring: use default group for postfix-exporter

### DIFF
--- a/monitoring/default.nix
+++ b/monitoring/default.nix
@@ -203,7 +203,6 @@ in {
         enable = config.services.postfix.enable;
         showqPath = "/var/lib/postfix/queue/public/showq";
         systemd.enable = true;
-        group = "systemd-journal";
       };
       services.prometheus.exporters.dovecot = {
         enable = config.services.dovecot2.enable;


### PR DESCRIPTION
The group set in [nixos/prometheus-postfix-exporter: set default group](https://github.com/mayflower/nixpkgs/pull/64) is allowed to access the journal, so setting it here is not needed anymore.